### PR TITLE
Fix phylax 1.2.0 formula metadata

### DIFF
--- a/Formula/phylax.rb
+++ b/Formula/phylax.rb
@@ -3,25 +3,23 @@ class Phylax < Formula
   homepage "https://github.com/phylaxsystems/credible-sdk"
   version "1.2.0"
 
-  if OS.mac?
-    if Hardware::CPU.arm?
-      url "https://github.com/phylaxsystems/credible-sdk/releases/download/#{version}/pcl-#{version}-macos-arm64.tar.gz"
-      sha256 ""
-    else
-      odie "Intel macOS is no longer supported."
-    end
-  elsif OS.linux?
-    if Hardware::CPU.intel?
+  on_macos do
+    depends_on arch: :arm64
+
+    url "https://github.com/phylaxsystems/credible-sdk/releases/download/#{version}/pcl-#{version}-macos-arm64.tar.gz"
+    sha256 "dac8590af37cff432cc9e85370399392012d91c479988e34562b890ece70cff6"
+  end
+
+  on_linux do
+    on_intel do
       url "https://github.com/phylaxsystems/credible-sdk/releases/download/#{version}/pcl-#{version}-linux-x86_64.tar.gz"
-      sha256 ""
-    elsif Hardware::CPU.arm?
-      url "https://github.com/phylaxsystems/credible-sdk/releases/download/#{version}/pcl-#{version}-linux-arm64.tar.gz"
-      sha256 ""
-    else
-      odie "Unsupported Linux architecture."
+      sha256 "60565c9211c0bb03fede1b4dc26198b4e93dcf30b1ac637cc02a68693d9f246a"
     end
-  else
-    odie "Unsupported operating system."
+
+    on_arm do
+      url "https://github.com/phylaxsystems/credible-sdk/releases/download/#{version}/pcl-#{version}-linux-arm64.tar.gz"
+      sha256 "651a1d93b20195f7d57c31ddca742701e1db7ffe2c5b94c3dd84def7b3ac6d76"
+    end
   end
 
   def install


### PR DESCRIPTION
## Summary
- add the published sha256 digests for the credible-sdk 1.2.0 pcl release assets
- switch the formula to Homebrew's on_macos/on_linux DSL so the macOS arm64 asset resolves correctly
- keep macOS limited to arm64 via Homebrew's arch requirement

## Verification
- HOMEBREW_CACHE=/tmp/homebrew-cache HOMEBREW_NO_AUTO_UPDATE=1 brew audit --strict phylaxsystems/pcl/phylax
- HOMEBREW_CACHE=/tmp/homebrew-cache HOMEBREW_NO_AUTO_UPDATE=1 brew install phylaxsystems/pcl/phylax
- HOMEBREW_CACHE=/tmp/homebrew-cache HOMEBREW_NO_AUTO_UPDATE=1 brew test phylaxsystems/pcl/phylax
- pcl --version